### PR TITLE
fix: CloseRequestHandler.canClose() is not called by the OnCloseRequest handler installed on the Tab panel installed by DockCommons.createTabber()

### DIFF
--- a/src/main/java/com/anchorage/docks/containers/common/DockCommons.java
+++ b/src/main/java/com/anchorage/docks/containers/common/DockCommons.java
@@ -81,17 +81,20 @@ public class DockCommons {
             Tab newTabPanel = new Tab(newDockNode.getContent().titleProperty().get());
             
             existTabPanel.setOnCloseRequest(event->{
-             
-                   existDockNode.undock();
-                   event.consume();
-            
+
+                if (existDockNode.getCloseRequestHandler() == null || existDockNode.getCloseRequestHandler().canClose()) {
+                    existDockNode.undock();
+                    event.consume();
+                }
+
             });
-            
+
             newTabPanel.setOnCloseRequest(event->{
-             
+                if (newDockNode.getCloseRequestHandler() == null || newDockNode.getCloseRequestHandler().canClose()) {
                    newDockNode.undock();
                    event.consume();
-            
+                }
+
             });
             
             existTabPanel.closableProperty().bind(existDockNode.closeableProperty());


### PR DESCRIPTION
for issue #22 